### PR TITLE
Compatibility with Ubuntu Focal / ROS Noetic

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -31,7 +31,7 @@
   <build_depend>google-mock</build_depend>
 
   <depend>boost</depend>
-  <depend>grpc</depend>
+  <depend>libgrpc++-dev</depend>  <!-- See: magclone rosdep -->
   <depend>libgflags-dev</depend>
   <depend>libgoogle-glog-dev</depend>
   <depend>protobuf-dev</depend>


### PR DESCRIPTION
* Point to libgrpc++-dev in package.xml
Otherwise we get the broken ROS grpc thingy.
See our rosdep file for the mapping.

* The Ubuntu version finally new enough to not require the hacks needed for Ubuntu 18 anymore (https://github.com/magazino/async_grpc/commit/f415bb513b5f38a8f1ec64ea9d1a589ed63f46e5)